### PR TITLE
Add Connection Properties

### DIFF
--- a/src/main/java/ru/tehkode/permissions/backends/sql/SQLBackend.java
+++ b/src/main/java/ru/tehkode/permissions/backends/sql/SQLBackend.java
@@ -75,11 +75,13 @@ public class SQLBackend extends PermissionBackend {
 		final String dbUri = getConfig().getString("uri", "");
 		final String dbUser = getConfig().getString("user", "");
 		final String dbPassword = getConfig().getString("password", "");
+		final String dbConnectionProperties = getConfig().getString("connectionProperties");
 
 		if (dbUri == null || dbUri.isEmpty()) {
 			getConfig().set("uri", "mysql://localhost/exampledb");
 			getConfig().set("user", "databaseuser");
 			getConfig().set("password", "databasepassword");
+			getConfig().set("connectionProperties","useSSL=false");
 			manager.getConfiguration().save();
 			throw new PermissionBackendException("SQL connection is not configured, see config.yml");
 		}
@@ -93,6 +95,7 @@ public class SQLBackend extends PermissionBackend {
 		this.ds.setUrl("jdbc:" + dbUri);
 		this.ds.setUsername(dbUser);
 		this.ds.setPassword(dbPassword);
+		this.ds.setConnectionProperties(dbConnectionProperties);
 		// https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
 		this.ds.setMaxActive((Runtime.getRuntime().availableProcessors() * 2) + 1);
 		this.ds.setMaxWait(200); // 4 ticks


### PR DESCRIPTION
Allow the data connection to pass connection properties adding support for MYSQL 5.7 and its implicit SSL requirements.
connection properties can be added to the config as a string, each property is recorded as name=value and delimited by `;` (semicolon)
ie
```YAML
connectionProperties="useSSL=false;property2=somevalue"
```